### PR TITLE
use correct framework

### DIFF
--- a/MonstercatNet.Sample.Wpf/MonstercatNet.Sample.Wpf.csproj
+++ b/MonstercatNet.Sample.Wpf/MonstercatNet.Sample.Wpf.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net80-windows</TargetFramework>
+        <TargetFramework>net8.0-windows</TargetFramework>
         <UseWPF>true</UseWPF>
         <UserSecretsId>31a9ef54-40ff-4c7c-81b1-c4c6e4bc1e99</UserSecretsId>
     </PropertyGroup>

--- a/MonstercatNet.Tests/MonstercatNet.Tests.csproj
+++ b/MonstercatNet.Tests/MonstercatNet.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net80</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
         <AssemblyName>MonstercatNet.Tests</AssemblyName>

--- a/build/Util/Constants.cs
+++ b/build/Util/Constants.cs
@@ -4,7 +4,7 @@ namespace Build
     {
         public const string Configuration = "Release";
         public const string Platform = "AnyCPU";
-        public const string TargetFramework = "net80";
+        public const string TargetFramework = "net8.0";
 
         public const string SolutionPath = "./MonstercatNet.sln";
         public const string AssemblyInfoPath = "./SharedAssemblyInfo.cs";


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)